### PR TITLE
Version upgrade of the maven-scm-provider-svn-commons dependency : 1.12.2 ==> 2.0.0-M3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target/
 .idea/
 *.iml
+/.settings/
+/.classpath
+/.project
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
   </developers>
 
   <properties>
-    <scmVersion>1.12.2</scmVersion>
+    <scmVersion>2.0.0-M3</scmVersion>    
     <svnUrl>https://github.com/olamy/maven-scm-provider-svnjava.git/trunk</svnUrl>
     <distUrlReleaseRepo>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distUrlReleaseRepo>
     <distUrlSnapshotRepo>https://oss.sonatype.org/content/repositories/snapshots</distUrlSnapshotRepo>

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/add/SvnJavaAddCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/add/SvnJavaAddCommand.java
@@ -94,9 +94,9 @@ public class SvnJavaAddCommand
             {
                 File fileToAdd = new File( fileSet.getBasedir(), file.toString() );
 
-                if ( getLogger().isDebugEnabled() )
+                if ( logger.isDebugEnabled() )
                 {
-                    getLogger().debug( "SVN adding file: " + fileToAdd.getAbsolutePath() );
+                	logger.debug( "SVN adding file: " + fileToAdd.getAbsolutePath() );
                 }
 
                 boolean forceAdd = parameters.getBoolean( CommandParameter.FORCE_ADD, false );

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommand.java
@@ -60,9 +60,9 @@ public class SvnJavaCheckInCommand
                                                       ScmVersion tag )
         throws ScmException
     {
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN commit directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN commit directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/checkout/SvnJavaCheckOutCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/checkout/SvnJavaCheckOutCommand.java
@@ -65,9 +65,9 @@ public class SvnJavaCheckOutCommand
                                                         ScmVersion version, boolean recursive )
         throws ScmException
     {
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnScmProviderRepository repository = (SvnScmProviderRepository) repo;
@@ -105,7 +105,7 @@ public class SvnJavaCheckOutCommand
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
 
-        ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), fileSet.getBasedir() );
+        ScmFileEventHandler handler = new ScmFileEventHandler( logger, fileSet.getBasedir() );
         SVNUpdateClient updateClient = javaRepo.getClientManager().getUpdateClient();
         updateClient.setEventHandler( handler );
 

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommand.java
@@ -64,9 +64,9 @@ public class SvnJavaDiffCommand
                                                 ScmVersion startRevision, ScmVersion endRevision )
         throws ScmException
     {
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN diff directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN diff directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
@@ -78,7 +78,7 @@ public class SvnJavaDiffCommand
 
         List<String> changeLists = new ArrayList<>();
 
-        ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), fileSet.getBasedir() );
+        ScmFileEventHandler handler = new ScmFileEventHandler( logger, fileSet.getBasedir() );
 
         SVNDiffClient diffClient = javaRepo.getClientManager().getDiffClient();
         diffClient.setEventHandler( handler );
@@ -90,7 +90,7 @@ public class SvnJavaDiffCommand
         {
 
 
-            SvnDiffConsumer consumer = new SvnDiffConsumer( getLogger(), fileSet.getBasedir() );
+            SvnDiffConsumer consumer = new SvnDiffConsumer( fileSet.getBasedir() );
 
             String line = in.readLine();
             while ( line != null )

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/export/SvnJavaExportCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/export/SvnJavaExportCommand.java
@@ -56,7 +56,7 @@ public class SvnJavaExportCommand
     {
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
 
-        ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), fileSet.getBasedir() );
+        ScmFileEventHandler handler = new ScmFileEventHandler(logger, fileSet.getBasedir() );
 
         javaRepo.getClientManager().getUpdateClient().setEventHandler( handler );
         String url = javaRepo.getUrl();

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/info/SvnJavaInfoCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/info/SvnJavaInfoCommand.java
@@ -90,16 +90,16 @@ public class SvnJavaInfoCommand
             SVNInfo svnInfo = null;
             
         	boolean isVersionedDirectory = SvnOperationFactory.isVersionedDirectory(f);
-        	getLogger().debug("Get info, isVersionedDirectory: " + isVersionedDirectory );
+        	logger.debug("Get info, isVersionedDirectory: " + isVersionedDirectory );
         	
         	if (isVersionedDirectory) 
         	{
-            	getLogger().info("Get info from versioned directory: " + f );
+        		logger.info("Get info from versioned directory: " + f );
         		svnInfo = javaRepo.getClientManager().getWCClient().doInfo( f, svnRev );
         	}
         	else {
         		SVNURL svnUrl = javaRepo.getSvnUrl();
-            	getLogger().info("Get info from svnUrl: " + svnUrl );
+        		logger.info("Get info from svnUrl: " + svnUrl );
             	svnInfo = javaRepo.getClientManager().getWCClient().doInfo( svnUrl, SVNRevision.UNDEFINED, svnRev );
         	}
 

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/remove/SvnJavaRemoveCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/remove/SvnJavaRemoveCommand.java
@@ -52,14 +52,14 @@ public class SvnJavaRemoveCommand
             throw new ScmException( "You must provide at least one file/directory to remove" );
         }
 
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN remove working directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN remove working directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
 
-        ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), fileSet.getBasedir() );
+        ScmFileEventHandler handler = new ScmFileEventHandler( logger, fileSet.getBasedir() );
 
         javaRepo.getClientManager().getWCClient().setEventHandler( handler );
 

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/status/SvnJavaStatusCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/status/SvnJavaStatusCommand.java
@@ -44,9 +44,9 @@ public class SvnJavaStatusCommand
     protected StatusScmResult executeStatusCommand( ScmProviderRepository repo, ScmFileSet fileSet )
         throws ScmException
     {
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN status directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN status directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/tag/SvnTagCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/tag/SvnTagCommand.java
@@ -78,9 +78,9 @@ public class SvnTagCommand
             throw new ScmException( "This provider doesn't support tagging subsets of a directory" );
         }
 
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnScmProviderRepository repository = (SvnScmProviderRepository) repo;

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/untag/SvnUnTagCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/untag/SvnUnTagCommand.java
@@ -68,7 +68,7 @@ public class SvnUnTagCommand extends AbstractUntagCommand implements SvnCommand
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
 
-        ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), scmFileSet.getBasedir() );
+        ScmFileEventHandler handler = new ScmFileEventHandler( logger, scmFileSet.getBasedir() );
 
         javaRepo.getClientManager().getWCClient().setEventHandler( handler );
 
@@ -106,9 +106,9 @@ public class SvnUnTagCommand extends AbstractUntagCommand implements SvnCommand
             throw new ScmException( "This provider doesn't support tagging subsets of a directory" );
         }
 
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN checkout directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnScmProviderRepository repository = (SvnScmProviderRepository) repo;

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/update/SvnJavaUpdateCommand.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/command/update/SvnJavaUpdateCommand.java
@@ -57,16 +57,16 @@ public class SvnJavaUpdateCommand
     {
         SvnScmProviderRepository repository = (SvnScmProviderRepository) repo;
 
-        if ( getLogger().isInfoEnabled() )
+        if ( logger.isInfoEnabled() )
         {
-            getLogger().info( "SVN update directory: " + fileSet.getBasedir().getAbsolutePath() );
+        	logger.info( "SVN update directory: " + fileSet.getBasedir().getAbsolutePath() );
         }
 
         SvnJavaScmProviderRepository javaRepo = (SvnJavaScmProviderRepository) repo;
 
         try
         {
-            ScmFileEventHandler handler = new ScmFileEventHandler( getLogger(), fileSet.getBasedir() );
+            ScmFileEventHandler handler = new ScmFileEventHandler( logger, fileSet.getBasedir() );
 
             SVNUpdateClient updateClient = javaRepo.getClientManager().getUpdateClient();
 
@@ -110,8 +110,8 @@ public class SvnJavaUpdateCommand
     protected ChangeLogCommand getChangeLogCommand()
     {
         SvnJavaChangeLogCommand command = new SvnJavaChangeLogCommand();
-
-        command.setLogger( getLogger() );
+        // CF : What to do here ?
+        //command.setLogger( logger );
 
         return command;
     }

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnjava/util/ScmFileEventHandler.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnjava/util/ScmFileEventHandler.java
@@ -1,5 +1,9 @@
 package org.apache.maven.scm.provider.svn.svnjava.util;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,17 +25,13 @@ package org.apache.maven.scm.provider.svn.svnjava.util;
 
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileStatus;
-import org.apache.maven.scm.log.ScmLogger;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
 import org.tmatesoft.svn.core.SVNCancelException;
 import org.tmatesoft.svn.core.SVNNodeKind;
 import org.tmatesoft.svn.core.wc.ISVNEventHandler;
 import org.tmatesoft.svn.core.wc.SVNEvent;
 import org.tmatesoft.svn.core.wc.SVNEventAction;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@link org.tmatesoft.svn.core.wc.ISVNStatusHandler} implementation for most
@@ -46,7 +46,7 @@ import java.util.List;
 public class ScmFileEventHandler
     implements ISVNEventHandler
 {
-    private final ScmLogger logger;
+    private final Logger logger;
 
     private final List<ScmFile> files = new ArrayList<>();
 
@@ -55,7 +55,7 @@ public class ScmFileEventHandler
     /**
      * The logger is used in alerting the user to unknown file statuses.
      */
-    public ScmFileEventHandler( ScmLogger logger, File baseDirectory )
+    public ScmFileEventHandler( Logger logger, File baseDirectory )
     {
         this.logger = logger;
 

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/SvnJavaScmTestUtils.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/SvnJavaScmTestUtils.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
-import junit.framework.Assert;
-
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.StringUtils;
@@ -35,6 +33,8 @@ import org.tmatesoft.svn.core.wc.ISVNOptions;
 import org.tmatesoft.svn.core.wc.SVNClientManager;
 import org.tmatesoft.svn.core.wc.SVNWCUtil;
 import org.tmatesoft.svn.core.wc.admin.SVNAdminClient;
+
+import junit.framework.Assert;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommandTckTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommandTckTest.java
@@ -1,5 +1,10 @@
 package org.apache.maven.scm.provider.svn.svnjava.command.checkin;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,31 +25,294 @@ package org.apache.maven.scm.provider.svn.svnjava.command.checkin;
  */
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
 
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.command.add.AddScmResult;
+import org.apache.maven.scm.command.checkin.CheckInScmResult;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.svn.command.checkin.SvnCheckInCommandTckTest;
 import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmTestUtils;
+import org.apache.maven.scm.util.FilenameUtils;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.StringUtils;
+import org.junit.Assume;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:dh-maven@famhq.com">David Hawkins</a>
- * @version $Id: SvnJavaCheckInCommandTckTest.java 96 2009-03-25 23:17:29Z oliver.lamy $
+ * @version $Id: SvnJavaCheckInCommandTckTest.java 96 2009-03-25 23:17:29Z
+ *          oliver.lamy $
  */
-public class SvnJavaCheckInCommandTckTest
-    extends SvnCheckInCommandTckTest
-{
+public class SvnJavaCheckInCommandTckTest extends SvnCheckInCommandTckTest {
 
-    /** {@inheritDoc} */
-    public void initRepo()
-        throws Exception
-    {
-        SvnJavaScmTestUtils.initializeRepository( getRepositoryRoot() );
-    }
+	/** {@inheritDoc} */
+	@Override
+	public void initRepo() throws Exception {
+		SvnJavaScmTestUtils.initializeRepository(getRepositoryRoot());
+	}
 
-    /** {@inheritDoc} */
-    public String getScmUrl()
-        throws Exception
-    {
-        return SvnJavaScmTestUtils.getScmUrl( new File( getRepositoryRoot(), "trunk" ) );
-    }
+	/** {@inheritDoc} */
+	@Override
+	public String getScmUrl() throws Exception {
+		return SvnJavaScmTestUtils.getScmUrl(new File(getRepositoryRoot(), "trunk"));
+	}
 
-    
+	@Test
+	public void testCheckInCommandFilesetWithBasedirOtherThanWorkingCopyRoot() throws Exception {
+		ScmProvider scmProvider = getScmManager().getProviderByUrl(getScmUrl());
+
+		Assume.assumeFalse("Local provider does not properly support basedir",
+				scmProvider.getScmType().equals("local"));
+		// Make sure that the correct files was checked out
+		File fooJava = new File(getWorkingCopy(), "src/main/java/Foo.java");
+
+		assertFalse("check Foo.java doesn't yet exist", fooJava.canRead());
+
+		// Change the files
+		createFooJava(fooJava);
+
+		AddScmResult addResult = scmProvider.add(getScmRepository(),
+				new ScmFileSet(new File(getWorkingCopy(), "src"), "main/java/Foo.java", null));
+
+		assertResultIsSuccess(addResult);
+
+		List<ScmFile> files = addResult.getAddedFiles();
+		assertNotNull(files);
+		assertEquals(1, files.size());
+
+		String fileWithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
+				files.get(0).getPath());
+		// SCM-998: filename separators not yet harmonized
+		assertEquals("/src/main/java/Foo.java", FilenameUtils.normalizeFilename(fileWithoutPathUnixStyle));
+
+		CheckInScmResult result = getScmManager().checkIn(getScmRepository(),
+				new ScmFileSet(new File(getWorkingCopy(), "src"), "**/Foo.java", null), "Commit message");
+
+		assertResultIsSuccess(result);
+
+		files = result.getCheckedInFiles();
+		assertNotNull(files);
+		assertEquals(1, files.size());
+
+		ScmFile file1 = files.get(0);
+		assertEquals(ScmFileStatus.CHECKED_IN, file1.getStatus());
+
+		String file1WithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
+				file1.getPath());
+		assertPath("/src/main/java/Foo.java", file1WithoutPathUnixStyle);
+
+		CheckOutScmResult checkoutResult = getScmManager().checkOut(getScmRepository(),
+				new ScmFileSet(getAssertionCopy()));
+
+		assertResultIsSuccess(checkoutResult);
+
+		fooJava = new File(getAssertionCopy(), "src/main/java/Foo.java");
+
+		assertTrue("check can read Foo.java", fooJava.canRead());
+
+	}
+
+	@Test
+	public void testCheckInCommandPartialFileset() throws Exception {
+		// Make sure that the correct files was checked out
+		File fooJava = new File(getWorkingCopy(), "src/main/java/Foo.java");
+
+		File barJava = new File(getWorkingCopy(), "src/main/java/Bar.java");
+
+		File readmeTxt = new File(getWorkingCopy(), "readme.txt");
+
+		assertFalse("check Foo.java doesn't yet exist", fooJava.canRead());
+
+		assertFalse("check Bar.java doesn't yet exist", barJava.canRead());
+
+		assertTrue("check can read readme.txt", readmeTxt.canRead());
+
+		// Change the files
+		createFooJava(fooJava);
+
+		createBarJava(barJava);
+
+		changeReadmeTxt(readmeTxt);
+
+		AddScmResult addResult = getScmManager().getProviderByUrl(getScmUrl()).add(getScmRepository(),
+				new ScmFileSet(getWorkingCopy(), "src/main/java/Foo.java", null));
+
+		assertResultIsSuccess(addResult);
+
+		CheckInScmResult result = getScmManager().checkIn(getScmRepository(),
+				new ScmFileSet(getWorkingCopy(), "**/Foo.java", null), "Commit message");
+
+		assertResultIsSuccess(result);
+
+		List<ScmFile> files = result.getCheckedInFiles();
+		assertNotNull(files);
+		assertEquals(1, files.size());
+
+		ScmFile file1 = files.get(0);
+		assertEquals(ScmFileStatus.CHECKED_IN, file1.getStatus());
+
+		String file1WithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
+				file1.getPath());
+		assertPath("/src/main/java/Foo.java", file1WithoutPathUnixStyle);
+
+		CheckOutScmResult checkoutResult = getScmManager().checkOut(getScmRepository(),
+				new ScmFileSet(getAssertionCopy()));
+
+		assertResultIsSuccess(checkoutResult);
+
+		fooJava = new File(getAssertionCopy(), "src/main/java/Foo.java");
+
+		barJava = new File(getAssertionCopy(), "src/main/java/Bar.java");
+
+		readmeTxt = new File(getAssertionCopy(), "readme.txt");
+
+		assertTrue("check can read Foo.java", fooJava.canRead());
+
+		assertFalse("check Bar.java doesn't exist", barJava.canRead());
+
+		assertTrue("check can read readme.txt", readmeTxt.canRead());
+
+		assertEquals("check readme.txt contents", "/readme.txt", FileUtils.fileRead(readmeTxt));
+	}
+
+	@Test
+	public void testCheckInCommandTest() throws Exception {
+		// Make sure that the correct files was checked out
+		File fooJava = new File(getWorkingCopy(), "src/main/java/Foo.java");
+
+		File barJava = new File(getWorkingCopy(), "src/main/java/Bar.java");
+
+		File readmeTxt = new File(getWorkingCopy(), "readme.txt");
+
+		assertFalse("check Foo.java doesn't yet exist", fooJava.canRead());
+
+		assertFalse("check Bar.java doesn't yet exist", barJava.canRead());
+
+		assertTrue("check can read readme.txt", readmeTxt.canRead());
+
+		// Change the files
+		createFooJava(fooJava);
+
+		createBarJava(barJava);
+
+		changeReadmeTxt(readmeTxt);
+
+		AddScmResult addResult = getScmManager().add(getScmRepository(),
+				new ScmFileSet(getWorkingCopy(), "src/main/java/Foo.java", null));
+
+		assertResultIsSuccess(addResult);
+
+		List<ScmFile> files = addResult.getAddedFiles();
+		assertNotNull(files);
+		assertEquals(1, files.size());
+		String fileWithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
+				files.get(0).getPath());
+		// SCM-998: filename separators not yet harmonized
+		assertEquals("/src/main/java/Foo.java", FilenameUtils.normalizeFilename(fileWithoutPathUnixStyle));
+
+		CheckInScmResult result = getScmManager().checkIn(getScmRepository(), new ScmFileSet(getWorkingCopy()),
+				"Commit message");
+
+		assertResultIsSuccess(result);
+
+		files = result.getCheckedInFiles();
+		assertNotNull(files);
+		assertEquals(2, files.size());
+
+		Map<String, ScmFile> fileMap = mapFilesByPath(files);
+		
+		ScmFile file1 = fileMap.get(StringUtils.replace(getWorkingCopy() + "/src/main/java/Foo.java", "\\", "/"));		
+		assertNotNull(file1);
+		assertEquals(ScmFileStatus.CHECKED_IN, file1.getStatus());
+
+		ScmFile file2 = fileMap.get(StringUtils.replace(getWorkingCopy() + "/readme.txt", "\\", "/"));
+		assertNotNull(file2);
+		assertEquals(ScmFileStatus.CHECKED_IN, file2.getStatus());
+
+		CheckOutScmResult checkoutResult = getScmManager().checkOut(getScmRepository(),
+				new ScmFileSet(getAssertionCopy()));
+
+		assertResultIsSuccess(checkoutResult);
+
+		fooJava = new File(getAssertionCopy(), "src/main/java/Foo.java");
+
+		barJava = new File(getAssertionCopy(), "src/main/java/Bar.java");
+
+		readmeTxt = new File(getAssertionCopy(), "readme.txt");
+
+		assertTrue("check can read Foo.java", fooJava.canRead());
+
+		assertFalse("check Bar.java doesn't exist", barJava.canRead());
+
+		assertTrue("check can read readme.txt", readmeTxt.canRead());
+
+		assertEquals("check readme.txt contents", "changed file", FileUtils.fileRead(readmeTxt));
+	}
+
+	private void createFooJava(File fooJava) throws Exception {
+		FileWriter output = new FileWriter(fooJava);
+
+		PrintWriter printer = new PrintWriter(output);
+		try {
+			printer.println("public class Foo");
+			printer.println("{");
+
+			printer.println("    public void foo()");
+			printer.println("    {");
+			printer.println("        int i = 10;");
+			printer.println("    }");
+
+			printer.println("}");
+		} finally {
+			IOUtil.close(output);
+			IOUtil.close(printer);
+		}
+	}
+
+	private void createBarJava(File barJava) throws Exception {
+		FileWriter output = new FileWriter(barJava);
+
+		PrintWriter printer = new PrintWriter(output);
+
+		printer.println("public class Bar");
+		printer.println("{");
+
+		printer.println("    public int bar()");
+		printer.println("    {");
+		printer.println("        return 20;");
+		printer.println("    }");
+
+		printer.println("}");
+
+		printer.close();
+
+		output.close();
+	}
+
+	private void changeReadmeTxt(File readmeTxt) throws Exception {
+		FileWriter output = null;
+
+		try {
+			output = new FileWriter(readmeTxt);
+
+			output.write("changed file");
+		} finally {
+			IOUtil.close(output);
+		}
+	}
+
+	private String createFilePathWithoutCompletePath(String workingcopyString, String relativePath) throws Exception {
+		String fileWithoutCompletePath = StringUtils.replace(relativePath, workingcopyString, "");
+		// for Windows compatibility
+		String fileWithoutPathUnixStyle = StringUtils.replace(fileWithoutCompletePath, "\\", "/");
+		return fileWithoutPathUnixStyle;
+	}
 }

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommandTckTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/checkin/SvnJavaCheckInCommandTckTest.java
@@ -106,8 +106,8 @@ public class SvnJavaCheckInCommandTckTest extends SvnCheckInCommandTckTest {
 		assertEquals(ScmFileStatus.CHECKED_IN, file1.getStatus());
 
 		String file1WithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
-				file1.getPath());
-		assertPath("/src/main/java/Foo.java", file1WithoutPathUnixStyle);
+				file1.getPath());		
+		assertPath("main/java/Foo.java", file1WithoutPathUnixStyle);
 
 		CheckOutScmResult checkoutResult = getScmManager().checkOut(getScmRepository(),
 				new ScmFileSet(getAssertionCopy()));
@@ -161,7 +161,7 @@ public class SvnJavaCheckInCommandTckTest extends SvnCheckInCommandTckTest {
 
 		String file1WithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
 				file1.getPath());
-		assertPath("/src/main/java/Foo.java", file1WithoutPathUnixStyle);
+		assertPath("src/main/java/Foo.java", file1WithoutPathUnixStyle);
 
 		CheckOutScmResult checkoutResult = getScmManager().checkOut(getScmRepository(),
 				new ScmFileSet(getAssertionCopy()));
@@ -228,12 +228,12 @@ public class SvnJavaCheckInCommandTckTest extends SvnCheckInCommandTckTest {
 		assertEquals(2, files.size());
 
 		Map<String, ScmFile> fileMap = mapFilesByPath(files);
-		
-		ScmFile file1 = fileMap.get(StringUtils.replace(getWorkingCopy() + "/src/main/java/Foo.java", "\\", "/"));		
+				
+		ScmFile file1 = fileMap.get("src/main/java/Foo.java");
 		assertNotNull(file1);
 		assertEquals(ScmFileStatus.CHECKED_IN, file1.getStatus());
 
-		ScmFile file2 = fileMap.get(StringUtils.replace(getWorkingCopy() + "/readme.txt", "\\", "/"));
+		ScmFile file2 = fileMap.get("readme.txt");
 		assertNotNull(file2);
 		assertEquals(ScmFileStatus.CHECKED_IN, file2.getStatus());
 

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommandTckTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommandTckTest.java
@@ -140,7 +140,7 @@ public class SvnJavaDiffCommandTckTest
         String fileWithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
         		file.getPath());
         
-        assertPath( "/src/main/java/org/Foo.java", fileWithoutPathUnixStyle );
+        assertPath( "src/main/java/org/Foo.java", fileWithoutPathUnixStyle );
 
         assertTrue( file.getStatus().isDiff() );
 
@@ -151,7 +151,7 @@ public class SvnJavaDiffCommandTckTest
         //Check readme.txt
         file = files.next();
 
-        assertPath( "/readme.txt", file.getPath() );
+        assertPath( "readme.txt", file.getPath() );
 
         assertTrue( file.getStatus().isDiff() );
 
@@ -163,7 +163,7 @@ public class SvnJavaDiffCommandTckTest
         //Check project.xml
         file = files.next();
 
-        assertPath( "/project.xml", file.getPath() );
+        assertPath( "project.xml", file.getPath() );
 
         postRangeStr = "+changed project.xml\n\\ No newline at end of file\n";
         actualStr = differences.get( file.getPath() ).toString();

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommandTckTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/diff/SvnJavaDiffCommandTckTest.java
@@ -1,5 +1,9 @@
 package org.apache.maven.scm.provider.svn.svnjava.command.diff;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,9 +24,22 @@ package org.apache.maven.scm.provider.svn.svnjava.command.diff;
  */
 
 import java.io.File;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.command.diff.DiffScmResult;
+import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.svn.command.diff.SvnDiffCommandTckTest;
 import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.codehaus.plexus.util.StringUtils;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:dh-maven@famhq.com">David Hawkins</a>
@@ -49,4 +66,116 @@ public class SvnJavaDiffCommandTckTest
     protected File getWorkingDirectory() {
         return super.getWorkingDirectory();
     }
+    
+    
+    @Test
+    public void testDiffCommand()
+        throws Exception
+    {
+        ScmRepository repository = getScmRepository();
+
+        // ----------------------------------------------------------------------
+        // Change the files
+        // ----------------------------------------------------------------------
+
+        //
+        // readme.txt is changed (changed file in the root directory)
+        // project.xml is added (added file in the root directory)
+        // src/test/resources is untouched (a empty directory is left untouched)
+        // src/test/java is untouched (a non empty directory is left untouched)
+        // src/test/java/org (a empty directory is added)
+        // src/main/java/org/Foo.java (a non empty directory is added)
+        //
+
+        // /readme.txt
+        ScmTestCase.makeFile( getWorkingCopy(), "/readme.txt", "changed readme.txt" );
+
+        // /project.xml
+        ScmTestCase.makeFile( getWorkingCopy(), "/project.xml", "changed project.xml" );
+
+        addToWorkingTree( getWorkingCopy(), new File( "project.xml" ), repository );
+
+        // /src/test/java/org
+        ScmTestCase.makeDirectory( getWorkingCopy(), "/src/test/java/org" );
+
+        addToWorkingTree( getWorkingCopy(), new File( "src/test/java/org" ), repository );
+
+        // /src/main/java/org/Foo.java
+        ScmTestCase.makeFile( getWorkingCopy(), "/src/main/java/org/Foo.java" );
+
+        addToWorkingTree( getWorkingCopy(), new File( "src/main/java/org" ), repository );
+
+        // src/main/java/org/Foo.java
+        addToWorkingTree( getWorkingCopy(), new File( "src/main/java/org/Foo.java" ), repository );
+
+        // ----------------------------------------------------------------------
+        // Diff the project
+        // ----------------------------------------------------------------------
+
+        ScmProvider provider = getScmManager().getProviderByUrl( getScmUrl() );
+        ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
+        DiffScmResult result = provider.diff( repository, fileSet, null, (ScmVersion) null );
+
+        assertNotNull( "The command returned a null result.", result );
+
+        assertResultIsSuccess( result );
+
+        List<ScmFile> changedFiles = result.getChangedFiles();
+
+        Map<String, CharSequence> differences = result.getDifferences();
+
+        assertEquals( "Expected 3 files in the changed files list " + changedFiles, 3, changedFiles.size() );
+
+        assertEquals( "Expected 3 files in the differences list " + differences, 3, differences.size() );
+
+        // ----------------------------------------------------------------------
+        // Assert the files in the changed files list
+        // ----------------------------------------------------------------------
+
+        Iterator<ScmFile> files = new TreeSet<ScmFile>( changedFiles ).iterator();
+
+        //Check Foo.java
+        ScmFile file = files.next();
+
+        String fileWithoutPathUnixStyle = createFilePathWithoutCompletePath(getWorkingCopy().toString(),
+        		file.getPath());
+        
+        assertPath( "/src/main/java/org/Foo.java", fileWithoutPathUnixStyle );
+
+        assertTrue( file.getStatus().isDiff() );
+
+        String postRangeStr = "+/src/main/java/org/Foo.java\n\\ No newline at end of file\n";
+        String actualStr = differences.get( file.getPath() ).toString();
+        assertTrue( actualStr.endsWith( postRangeStr ) );
+
+        //Check readme.txt
+        file = files.next();
+
+        assertPath( "/readme.txt", file.getPath() );
+
+        assertTrue( file.getStatus().isDiff() );
+
+        postRangeStr =
+            "-/readme.txt\n\\ No newline at end of file\n+changed readme.txt\n\\ No newline at end of file\n";
+        actualStr = differences.get( file.getPath() ).toString();
+        assertTrue( actualStr.endsWith( postRangeStr ) );
+
+        //Check project.xml
+        file = files.next();
+
+        assertPath( "/project.xml", file.getPath() );
+
+        postRangeStr = "+changed project.xml\n\\ No newline at end of file\n";
+        actualStr = differences.get( file.getPath() ).toString();
+        assertTrue( actualStr.endsWith( postRangeStr ) );
+
+        assertTrue( file.getStatus().isDiff() );
+    }
+    
+	private String createFilePathWithoutCompletePath(String workingcopyString, String relativePath) throws Exception {
+		String fileWithoutCompletePath = StringUtils.replace(relativePath, workingcopyString, "");
+		// for Windows compatibility
+		String fileWithoutPathUnixStyle = StringUtils.replace(fileWithoutCompletePath, "\\", "/");
+		return fileWithoutPathUnixStyle;
+	}
 }

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/info/SvnJavaInfoCommandTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/info/SvnJavaInfoCommandTest.java
@@ -1,21 +1,18 @@
 package org.apache.maven.scm.provider.svn.svnjava.command.info;
 
-import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.command.info.InfoItem;
-import org.apache.maven.scm.command.info.InfoScmResult;
-import org.apache.maven.scm.log.DefaultLog;
-import org.apache.maven.scm.log.ScmLogger;
-import org.apache.maven.scm.manager.ScmManager;
-import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmProvider;
-import org.apache.maven.scm.provider.svn.svnjava.repository.SvnJavaScmProviderRepository;
-import org.codehaus.plexus.PlexusTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.tmatesoft.svn.core.SVNURL;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.command.info.InfoItem;
+import org.apache.maven.scm.command.info.InfoScmResult;
+import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmProvider;
+import org.apache.maven.scm.provider.svn.svnjava.repository.SvnJavaScmProviderRepository;
+import org.junit.Test;
+import org.tmatesoft.svn.core.SVNURL;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -40,7 +37,7 @@ import java.nio.file.Paths;
  * @author <a href="mailto:olamy@apache.org">olamy</a>
  */
 public class SvnJavaInfoCommandTest
-    extends PlexusTestCase
+      extends ScmTestCase
 {
 
     private Path checkoutPath = Paths.get( getBasedir(), "/target/", getClass().getName() );
@@ -53,13 +50,12 @@ public class SvnJavaInfoCommandTest
             return;
         }
 
-        ScmManager scmManager = (ScmManager) lookup( ScmManager.ROLE );
         String url = System.getProperty( "svnUrl" );
         String scmUrl = "scm:javasvn:" + url;
 
-        SvnJavaScmProvider provider = (SvnJavaScmProvider) scmManager.getProviderByUrl( scmUrl );
+        SvnJavaScmProvider provider = (SvnJavaScmProvider) getScmManager().getProviderByUrl( scmUrl );
 
-        provider.checkOut( scmManager.makeScmRepository( scmUrl ), //
+        provider.checkOut( getScmManager().makeScmRepository( scmUrl ), //
                            new ScmFileSet( checkoutPath.toFile() ) );
     }
 
@@ -68,22 +64,19 @@ public class SvnJavaInfoCommandTest
         throws Exception
     {
         prepareCopy();
-        ScmManager scmManager = (ScmManager) lookup( ScmManager.ROLE );
 
         String url = System.getProperty( "scmUrlProject" );
         String scmUrl = "scm:javasvn:" + url;
         SvnJavaScmProviderRepository repository =
             new SvnJavaScmProviderRepository( SVNURL.parseURIEncoded( url ), scmUrl );
 
-        SvnJavaScmProvider provider = (SvnJavaScmProvider) scmManager.getProviderByUrl( scmUrl );
+        SvnJavaScmProvider provider = (SvnJavaScmProvider) getScmManager().getProviderByUrl( scmUrl );
 
         InfoScmResult result = provider.info( repository, new ScmFileSet( checkoutPath.toFile() ), null );
         InfoItem item = result.getInfoItems().get( 0 );
         assertTrue( item.getRevision() != null );
 
         SvnJavaInfoCommand command = new SvnJavaInfoCommand();
-        ScmLogger logger = new DefaultLog();
-        command.setLogger(logger);
         result = command.executeInfoCommand( repository, new ScmFileSet( checkoutPath.toFile() ), null, true, null );
         item = result.getInfoItems().get( 0 );
         assertTrue( item.getRevision() != null );
@@ -94,22 +87,19 @@ public class SvnJavaInfoCommandTest
         throws Exception
     {
 
-        prepareCopy();
-        ScmManager scmManager = (ScmManager) lookup( ScmManager.ROLE );
+        prepareCopy();        
         String url = getBasedir();
         String scmUrl = "scm:javasvn:" + url;
         SvnJavaScmProviderRepository repository =
             new SvnJavaScmProviderRepository( SVNURL.fromFile( checkoutPath.toFile() ), scmUrl );
 
-        SvnJavaScmProvider provider = (SvnJavaScmProvider) scmManager.getProviderByUrl( scmUrl );
+        SvnJavaScmProvider provider = (SvnJavaScmProvider) getScmManager().getProviderByUrl( scmUrl );
 
         InfoScmResult result = provider.info( repository, new ScmFileSet( checkoutPath.toFile() ), null );
         InfoItem item = result.getInfoItems().get( 0 );
         assertTrue( item.getRevision() != null );
 
         SvnJavaInfoCommand command = new SvnJavaInfoCommand();
-        ScmLogger logger = new DefaultLog();
-        command.setLogger(logger);
         result = command.executeInfoCommand( repository, new ScmFileSet( checkoutPath.toFile() ), null, true, null );
         item = result.getInfoItems().get( 0 );
         assertTrue( item.getRevision() != null );

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/list/SvnJavaListCommandTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/list/SvnJavaListCommandTest.java
@@ -1,18 +1,18 @@
 package org.apache.maven.scm.provider.svn.svnjava.command.list;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.command.list.ListScmResult;
-import org.apache.maven.scm.manager.ScmManager;
 import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmProvider;
 import org.apache.maven.scm.provider.svn.svnjava.repository.SvnJavaScmProviderRepository;
-import org.codehaus.plexus.PlexusTestCase;
-import org.junit.Before;
 import org.junit.Test;
 import org.tmatesoft.svn.core.SVNURL;
-
-import java.io.File;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -37,20 +37,19 @@ import java.io.File;
  * @author <a href="mailto:olamy@apache.org">olamy</a>
  */
 public class SvnJavaListCommandTest
-    extends PlexusTestCase
+	  extends ScmTestCase
 {
 
     @Test
     public void testList()
         throws Exception
     {
-        ScmManager scmManager = (ScmManager) lookup( ScmManager.ROLE );
         String url = System.getProperty( "svnUrl" );
         String scmUrl = "scm:javasvn:" + url;
         SvnJavaScmProviderRepository repository =
             new SvnJavaScmProviderRepository( SVNURL.parseURIEncoded( url ), scmUrl );
 
-        SvnJavaScmProvider provider = (SvnJavaScmProvider) scmManager.getProviderByUrl( scmUrl );
+        SvnJavaScmProvider provider = (SvnJavaScmProvider) getScmManager().getProviderByUrl( scmUrl );
 
         ScmFileSet fileSet = new ScmFileSet( new File( "." ), new File( "." ) );
 

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/status/SvnJavaStatusCommandTckTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/command/status/SvnJavaStatusCommandTckTest.java
@@ -31,6 +31,11 @@ import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmTestUtils;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.StringUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;

--- a/src/test/java/org/apache/maven/scm/provider/svn/svnjava/repository/SvnScmProviderRepositoryTest.java
+++ b/src/test/java/org/apache/maven/scm/provider/svn/svnjava/repository/SvnScmProviderRepositoryTest.java
@@ -1,5 +1,13 @@
 package org.apache.maven.scm.provider.svn.svnjava.repository;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,10 +34,6 @@ import org.apache.maven.scm.provider.svn.repository.SvnScmProviderRepository;
 import org.apache.maven.scm.provider.svn.svnjava.SvnJavaScmProvider;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.repository.ScmRepositoryException;
-
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
@@ -134,7 +138,7 @@ public class SvnScmProviderRepositoryTest
             return;
         }
 
-        ScmManager scmManager = (ScmManager) lookup( ScmManager.ROLE );
+        ScmManager scmManager = (ScmManager) lookup( ScmManager.class.getName() );
         String url = System.getProperty( "svnUrl" );
         String scmUrl = "scm:javasvn:" + url;
 


### PR DESCRIPTION
Version upgrade of the maven-scm-provider-svn-commons dependency : 1.12.2 ==> 2.0.0-M3

Follow up to my enhancement request here : https://github.com/olamy/maven-scm-provider-svnjava/issues/55#issuecomment-1445266329

Directly from my main branch, hope it's ok.
Modified a few classes to use SL4J instead of SCMLogger.
Tests are ok (extended ScmTestCase instead of PlexusTestCase)
Only one doubt : what to do with SvnJavaUpdateCommand.getChangeLogCommand() since AbstractCommand no longer uses ScmLogger ? 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
